### PR TITLE
Transitory upgrade to android 5.16.6.17198

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAUI
 
-* Android: Meeting SDK Version: 5.15.10.1778 [![AndroidMauiNugetShield]][AndroidMauiNugetLink] 
+* Android: Meeting SDK Version: 5.16.6.17198 [![AndroidMauiNugetShield]][AndroidMauiNugetLink] 
 
 * iOS: MobileRTC Version: 6.1.0.16235 [![iOSMAUINugetShield]][iOSMAUINugetLink]
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,23 @@ Refer to the Zoom Meeting SDK documentation on how to create a jwt
 ```
 
 ## Android Gotchas
-* Requires your android app to compile for Android 12
+
+* My consuming app required the following nuget versions
+```
+    <!-- Android Only Nuget Packages -->
+    <ItemGroup Condition="'$(IsAndroid)' AND '$(Configuration)'!='Test'">
+      <PackageReference Include="zoommeetingsdk.dotnet.android" Version="5.16.6.17198" />
+      <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.1-alpha06" />
+      <PackageReference Include="Xamarin.Google.Android.Material" Version="1.11.0.1" />
+      <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.11.0.1" />
+      <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.1.1" />
+      <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.6"/>
+      <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.5"/>
+
+    </ItemGroup>
+
+```
+* Requires your android app to compile for Android 13
 
 * The csproj of your android app needs a particular version of AndroidX.Core which is out of the bounds of the latest Xamarin.Forms version. It is likely to remain so with MAUI here now, and XF development at a minimum from Microsoft. I haven't noticed any negative consequences in my XF app, but it is something to watch out for in your implementation.
 

--- a/src/MAUI/Android/Lottie.Android/Lottie.Android.csproj
+++ b/src/MAUI/Android/Lottie.Android/Lottie.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android</TargetFrameworks>
+    <TargetFrameworks>net8.0-android</TargetFrameworks>
     <AssemblyName>Lottie.Android</AssemblyName>
     <RootNamespace>Lottie.Android</RootNamespace>
     <Description>Render After Effects animations natively on Android, iOS, MacOS, TVOs and UWP</Description>
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Square.OkIO" Version="1.17.4" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.4.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.3" />
     <!-- None Include="Additions\*;Jars\*;Transforms\*" /-->
     <LibraryProjectZip Include="Jars\*.aar" />
     <!--<JavaSourceJar Include="JavaDocs\*.jar" />-->

--- a/src/MAUI/Android/MobileRTC.MAUI/MobileRTC.MAUI.csproj
+++ b/src/MAUI/Android/MobileRTC.MAUI/MobileRTC.MAUI.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFramework>net8.0-android</TargetFramework>
     <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>zoommeetingsdk.dotnet.android</PackageId>
-    <Version>5.15.10.15778</Version>
+    <Version>5.16.6.17198</Version>
     <Title>ZoomMeetingSDK Binding for MAUI Android</Title>
     <Authors>Visual Service, Adam Diament</Authors>
     <PackageProjectUrl>https://github.com/VisualService/dotnet-zoom-meeting-SDK</PackageProjectUrl>
@@ -32,19 +32,23 @@
     <PackageReference Include="Xamarin.Android.Glide" Version="4.15.1.2" />
     <PackageReference Include="Naxam.EventBus.Droid" Version="3.0.0-pre1" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.3.1" />
+    <!-- LOTTIE GOES HERE IN BUILD.GRADLE - WE RELY ON OUR CUSTOM PROJ-->
     <PackageReference Include="Xamarin.AndroidX.Window" Version="1.1.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.0.1" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.0.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.10.1.2" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.6.1.3" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.6.1.3" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.6.1.3" />
     <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.6.1" />
+    <PackageReference Include="Naxam.RxJava2.Droid" Version="2.1.2"/>
+    <PackageReference Include="Karamunting.AndroidX.DaveMorrissey.SubsamplingScaleImageView" Version="3.10.0"/>
+    <PackageReference Include="Xamarin.AndroidX.WebKit" Version="1.11.0.3"/>
   </ItemGroup>
   <ItemGroup>
     <!-- Include the .aar files in the NuGet package output, placing them in the same directory as other package files -->
-    <None Pack="true" PackagePath="\lib\net7.0-android33.0" Include="../ZoomCommonLib.MAUI/commonlib.5.15.10.15778.aar" />
-    <None Pack="true" PackagePath="\lib\net7.0-android33.0" Include="../Lottie.Android/Jars/lottie-4.2.2.aar" />
+    <None Pack="true" PackagePath="\lib\net8.0-android34.0" Include="../ZoomCommonLib.MAUI/commonlib.5.16.6.1798.aar" />
+    <None Pack="true" PackagePath="\lib\net8.0-android34.0" Include="../Lottie.Android/Jars/lottie-4.2.2.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lottie.Android\Lottie.Android.csproj" PrivateAssets="all" />

--- a/src/MAUI/Android/MobileRTC.MAUI/Transforms/Metadata.xml
+++ b/src/MAUI/Android/MobileRTC.MAUI/Transforms/Metadata.xml
@@ -24,9 +24,10 @@
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.actionsheet']/class[@name='ZmBaseActionSheetAdapter']/method[@name='onCreateViewHolder' and count(parameter)=2 and parameter[1][@type='android.view.ViewGroup'] and parameter[2][@type='int']]" name="managedOverride">override</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.actionsheet']/class[@name='ZmBaseActionSheetAdapter']/method[@name='onBindViewHolder' and count(parameter)=2 and parameter[1][@type='us.zoom.androidlib.widget.pinnedsectionrecyclerview.BaseRecyclerViewAdapter.BaseViewHolder'] and parameter[2][@type='int']]" name="managedOverride">override</attr>
 	<attr path="/api/package[@name='us.zoom.uicommon.widget.view']/class[@name='ZMHorizontalListView']/method[@name='getAdapter' and count(parameter)=0]" name="managedOverride">virtual</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.confapp.proctoring']/class[@name='ZmProctoringGalleryItemView']/method[@name='getDisplayUsers' and count(parameter)=2 and parameter[1][@type='int'] and parameter[2][@type='int']]" name="visibility">protected</attr>
+        <!-- Those classes was changed of return value -->
 
-	<!-- Those classes was changed of return value -->
-	<attr path="/api/package[@name='com.zipow.videobox.view.sip']/class[@name='PhoneCallsAdapter']/method[@name='getItem' and count(parameter)=1 and parameter[1][@type='int']]" name="managedReturn">Java.Lang.Object</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.view.sip']/class[@name='PhoneCallsAdapter']/method[@name='getItem' and count(parameter)=1 and parameter[1][@type='int']]" name="managedReturn">Java.Lang.Object</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.view']/class[@name='PAttendeeListAdapter']/method[@name='getItem' and count(parameter)=1 and parameter[1][@type='int']]" name="managedReturn">Java.Lang.Object</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.view.sip']/class[@name='ZoomSipPhoneAdapter']/method[@name='getItem' and count(parameter)=1 and parameter[1][@type='int']]" name="managedReturn">Java.Lang.Object</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.view.sip']/class[@name='PhonePBXCallHistoryAdapter']/method[@name='getItemById' and count(parameter)=1 and parameter[1][@type='java.lang.String']]" name="managedReturn">Java.Lang.Object</attr>
@@ -58,9 +59,22 @@
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.actionsheet']/class[@name='ZmBaseActionSheetAdapter']/method[@name='onCreateViewHolder' and count(parameter)=2 and parameter[1][@type='android.view.ViewGroup'] and parameter[2][@type='int']]" name="managedReturn">Java.Lang.Object</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.actionsheet']/class[@name='ZmBaseActionSheetAdapter']/method[@name='onBindViewHolder' and count(parameter)=2 and parameter[1][@type='us.zoom.androidlib.widget.pinnedsectionrecyclerview.BaseRecyclerViewAdapter.BaseViewHolder'] and parameter[2][@type='int']]" name="managedReturn">void</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.actionsheet']/class[@name='ZmBaseActionSheetAdapter']/method[@name='onCreateViewHolder' and count(parameter)=2 and parameter[1][@type='android.view.ViewGroup'] and parameter[2][@type='int']]" name="managedReturn">AndroidX.RecyclerView.Widget.RecyclerView.ViewHolder</attr>
-
-	<!-- Obfuscating those classes because they are publicity inherited by public SDK members -->
-	<remove-node path="/api/package[@name='com.zipow.videobox.confapp.meeting.videoeffects.videofilter']/class[@name='ZmVideoFilterRecyclerAdapter']">
+  <attr path="/api/package[@name='us.zoom.zmsg.dataflow.viewbean']/class[@name='MMTextBean']/method[@name='b' and count(parameter)=0]" name="visibility">protected</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.sip.server']/class[@name='ICallItemBase']/method[@name='I' and count(parameter)=0]" name="managedName">BoolI</attr>
+  <attr path="/api/package[@name='us.zoom.zclips.ui.recording']/class[@name='ZClipsRecordingPageController']/method[@name='b' and count(parameter)=0]" name="managedName">BoolB</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.sip.server']/class[@name='CmmSIPMessageManager']/method[@name='b' and count(parameter)=1 and parameter[1][@type='java.lang.String']]" name="managedName">BoolB</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.sip.server']/class[@name='ICallItemBase']/method[@name='j' and count(parameter)=0]" name="managedName">NewJ</attr> 
+        <!-- Obfuscating those classes because they are publicity inherited by public SDK members -->
+  <remove-node path="/api/package[@name='us.zoom.zclips.ui.recording']/class[@name='ZClipsRecordingPageController']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.zimmsg.draft']/class[@name='DraftsAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='com.zipow.videobox.confapp.proctoring']/class[@name='ZmProctoringGalleryRecyclerAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='com.zipow.videobox.fragment.adapter']/class[@name='SigninHistoryAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.presentmode.viewer.fragment.delegate']/class[@name='BaseLifecycleDelegate']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.zimmsg.filecontent']/class[@name='MMContentSearchMessagesAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.zmsg.dataflow.viewbean']/class[@name='MMTextBean']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.zimmsg.mentions']/class[@name='MMMentionsListAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='us.zoom.zimmsg.filecontent']/class[@name='MMContentSearchFilesAdapter']"></remove-node>
+  <remove-node path="/api/package[@name='com.zipow.videobox.confapp.meeting.videoeffects.videofilter']/class[@name='ZmVideoFilterRecyclerAdapter']">
 	</remove-node>
 	<remove-node path="/api/package[@name='com.zipow.videobox.confapp.meeting.videoeffects.virtualbackground']/class[@name='ZmVirtualBackgroundRecyclerAdapter']">
 	</remove-node>
@@ -266,4 +280,10 @@
 	<attr path="/api/package[@name='com.zipow.videobox.common.user']/class[@name='PTUserProfile']/method[@name='m' and count(parameter)=0]" name="managedName">NewM</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.common.user']/class[@name='PTUserSetting']/method[@name='y0' and count(parameter)=1 and parameter[1][@type='java.lang.String']]" name="managedName">NewY0</attr>
 	<attr path="/api/package[@name='com.zipow.videobox.confapp.meeting.scene.uservideo']/class[@name='ZmSignLanguageGalleryItemView']/method[@name='getDisplayUsers' and count(parameter)=2 and parameter[1][@type='int'] and parameter[2][@type='int']]" name="visibility">protected</attr>
+  <attr path="/api/package[@name='us.zoom.zclips.ui.recording']/class[@name='ZClipsRecordingPageController']/method[@name='a' and count(parameter)=0]" name="managedName">NewA</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.sip.server']/class[@name='CmmSIPMessageManager']/method[@name='a' and count(parameter)=1 and parameter[1][@type='java.lang.String']]" name="managedName">NewA</attr>
+  <attr path="/api/package[@name='com.zipow.videobox.sip.server']/class[@name='CmmSIPVoiceMailItem']/method[@name='a' and count(parameter)=0]" name="managedName">NewA</attr>
+<attr path="/api/package[@name='com.zipow.videobox.login.view']/class[@name='LoginView']/method[@name='p' and count(parameter)=0]" name="managedName">NewP</attr>
+  <attr path="/api/package[@name='us.zoom.uicommon.widget.recyclerview']/class[@name='RangeRemoveList']/method[@name='size' and count(parameter)=0]" name="final">false</attr>
+  <attr path="/api/package[@name='us.zoom.uicommon.widget.recyclerview']/class[@name='RangeRemoveList']/method[@name='size' and count(parameter)=0]" name="managedOverride">none</attr>
 </metadata>

--- a/src/MAUI/Android/MobileRTC.MAUI/mobilertc.5.15.10.15778.aar
+++ b/src/MAUI/Android/MobileRTC.MAUI/mobilertc.5.15.10.15778.aar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:044cd9086fced8f823e4c4dc00d1310806db0b91b31ed380ff789aae4d417134
-size 240977228

--- a/src/MAUI/Android/MobileRTC.MAUI/mobilertc.5.16.6.1798.aar
+++ b/src/MAUI/Android/MobileRTC.MAUI/mobilertc.5.16.6.1798.aar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59d395757096c5871250910ac9c28943c5d9b60abf4343c479ff32bcdba13b8b
+size 236397635

--- a/src/MAUI/Android/ZoomCommonLib.MAUI/ZoomCommonLib.MAUI.csproj
+++ b/src/MAUI/Android/ZoomCommonLib.MAUI/ZoomCommonLib.MAUI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFramework>net8.0-android</TargetFramework>
     <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/MAUI/Android/ZoomCommonLib.MAUI/commonlib.5.15.10.15778.aar
+++ b/src/MAUI/Android/ZoomCommonLib.MAUI/commonlib.5.15.10.15778.aar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:085cba57a5627f055b97881b2ea3333d057e096e97958d69df7bbf39efdab175
-size 4098163

--- a/src/MAUI/Android/ZoomCommonLib.MAUI/commonlib.5.16.6.1798.aar
+++ b/src/MAUI/Android/ZoomCommonLib.MAUI/commonlib.5.16.6.1798.aar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b913eafc025ea909def97831a878f3c8eaa703afea158c86e831a474d9da59
+size 4280548


### PR DESCRIPTION
 I tried upgrading to the latest v6, but encountered a lot of binding issues. This upgrade came with less surprises and satisfies the minimum for another 3 months and will allow apps to keep working until November 2024. NOTE android apps must compile to max android 13 (api 33). API 34 will cause a runtime sdk init failure. API 34 is required for new apps on google play from 31st August 2024, so submit your app referencing this new package before that date, if you need the app on the store. Upgrading to minimum zoom 5.17.0 is required to make API 34 work, that is going to be my next job.

NOTE 
My consuming app needed the following nugets to compile and work

```
    <!-- Android Only Nuget Packages -->
    <ItemGroup Condition="'$(IsAndroid)' AND '$(Configuration)'!='Test'">
      <PackageReference Include="zoommeetingsdk.dotnet.android" Version="5.16.6.17198" />
      <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.1-alpha06" />
      <PackageReference Include="Xamarin.Google.Android.Material" Version="1.11.0.1" />
      <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.11.0.1" />
      <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.1.1" />
      <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.6"/>
      <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.5"/>

    </ItemGroup>
```